### PR TITLE
added the repo interface to the editor actions params

### DIFF
--- a/src/events/editor_action.ts
+++ b/src/events/editor_action.ts
@@ -2,6 +2,7 @@ import { PluginInterface } from "../entities/plugin";
 import { FileInterface } from "../entities/file";
 import { ProjectInterface } from "../entities/project";
 import { AuthInterface } from "../entities/auth";
+import { RepoInterface } from "../entities/repo";
 
 // The EditorAction event
 export interface EditorActionInterface {
@@ -35,7 +36,8 @@ export class EditorAction implements EditorActionInterface {
 
 export interface EditorActionParams
   extends AuthInterface,
-    PluginInterface,
-    FileInterface,
-    ProjectInterface,
-    EditorActionInterface {}
+  RepoInterface,
+  PluginInterface,
+  FileInterface,
+  ProjectInterface,
+  EditorActionInterface { }

--- a/src/utils/env_helper.ts
+++ b/src/utils/env_helper.ts
@@ -28,8 +28,13 @@ export function getPackageInfo(): any {
 }
 
 export function getPackageInfoFromFile(): any {
-  const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
-  const version = packageJson.version;
-  const name = packageJson.name;
-  return { name, version };
+  try {
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    const version = packageJson.version;
+    const name = packageJson.name;
+    return { name, version };
+  } catch (e) {
+    // error reading the package json, return default info
+    return { name: "swdc-tracker", version: "" };
+  }
 }

--- a/src/utils/env_helper.ts
+++ b/src/utils/env_helper.ts
@@ -16,25 +16,22 @@ export function isTestMode(): boolean {
   return getTrackerMode() === TrackerMode.TEST ? true : false;
 }
 
-export function getPackageInfo(): any {
-  let version = process.env.npm_package_version;
-  let name = process.env.npm_package_name;
-  if (!version) {
-    const nameVersionInfo = getPackageInfoFromFile();
-    name = nameVersionInfo.name;
-    version = nameVersionInfo.version;
+export function getPackageJson(): any {
+  try {
+    return JSON.parse(fs.readFileSync("package.json", "utf8"));
+  } catch (e) {
+    console.log("error reading package info", e);
   }
-  return { name, version };
+  return null;
 }
 
 export function getPackageInfoFromFile(): any {
-  try {
-    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const packageJson = getPackageJson();
+  if (packageJson) {
     const version = packageJson.version;
     const name = packageJson.name;
     return { name, version };
-  } catch (e) {
-    // error reading the package json, return default info
-    return { name: "swdc-tracker", version: "" };
   }
+  // 1.0.21 was the 1st version when this function was introduced
+  return { name: "swdc-tracker", version: "1.0.21" };
 }

--- a/src/utils/env_helper.ts
+++ b/src/utils/env_helper.ts
@@ -1,3 +1,5 @@
+const fs = require("fs");
+
 export enum TrackerMode {
   TEST = "test",
   PROD = "prod",
@@ -12,4 +14,22 @@ export function getTrackerMode(): TrackerMode {
 
 export function isTestMode(): boolean {
   return getTrackerMode() === TrackerMode.TEST ? true : false;
+}
+
+export function getPackageInfo(): any {
+  let version = process.env.npm_package_version;
+  let name = process.env.npm_package_name;
+  if (!version) {
+    const nameVersionInfo = getPackageInfoFromFile();
+    name = nameVersionInfo.name;
+    version = nameVersionInfo.version;
+  }
+  return { name, version };
+}
+
+export function getPackageInfoFromFile(): any {
+  const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const version = packageJson.version;
+  const name = packageJson.name;
+  return { name, version };
 }

--- a/src/utils/env_helper.ts
+++ b/src/utils/env_helper.ts
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const pckg = require("../../package.json");
 
 export enum TrackerMode {
   TEST = "test",
@@ -17,21 +17,14 @@ export function isTestMode(): boolean {
 }
 
 export function getPackageJson(): any {
-  try {
-    return JSON.parse(fs.readFileSync("package.json", "utf8"));
-  } catch (e) {
-    console.log("error reading package info", e);
+  if (pckg) {
+    return pckg;
   }
-  return null;
-}
 
-export function getPackageInfoFromFile(): any {
-  const packageJson = getPackageJson();
-  if (packageJson) {
-    const version = packageJson.version;
-    const name = packageJson.name;
-    return { name, version };
-  }
-  // 1.0.21 was the 1st version when this function was introduced
-  return { name: "swdc-tracker", version: "1.0.21" };
+  // unable to import the package json, use defaults
+  // 1.0.21 is the version this was introduced
+  return {
+    name: "swdc-tracker",
+    version: "1.0.21"
+  };
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -8,6 +8,18 @@ export function setBaseUrl(url: string) {
     baseURL: url,
     timeout: 15000 // timeout so we're not getting ECONNRESET
   });
+
+  // set teh tracker version and ID
+  let version = process.env.npm_package_version;
+  let name = process.env.npm_package_name;
+  if (!version) {
+    const fs = require("fs");
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    version = packageJson.version;
+    name = packageJson.name;
+  }
+  axiosClient.defaults.headers.common["X-SWDC-Tracker-Version"] = version || "";
+  axiosClient.defaults.headers.common["X-SWDC-Tracker-Id"] = name || "swdc-tracker";
 }
 
 export async function get(endpoint: string, jwt?: string) {
@@ -19,7 +31,8 @@ export async function get(endpoint: string, jwt?: string) {
     // we need to catch an error so we're not getting this for example;
     // UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 127.0.0.1:80
     // at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16)
-    console.log("swdc-tracker get request error", e);
+    const msg = e.message || e.code;
+    console.log("swdc-tracker get request error", msg);
     return e;
   });
   return result;
@@ -28,7 +41,8 @@ export async function get(endpoint: string, jwt?: string) {
 export async function post(endpoint: string, body: any, jwt: string) {
   axiosClient.defaults.headers.common["Authorization"] = jwt;
   const result = await axiosClient.post(endpoint, body).catch((e: any) => {
-    console.log("swdc-tracker post request error", e);
+    const msg = e.message || e.code;
+    console.log("swdc-tracker post request error", msg);
     return e;
   });
   return result;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getPackageInfoFromFile } from "./env_helper";
+import { getPackageJson } from "./env_helper";
 
 // build the axios api base url
 let axiosClient: any = {};
@@ -11,9 +11,9 @@ export function setBaseUrl(url: string) {
   });
 
   // set the tracker version and ID
-  const { name, version } = getPackageInfoFromFile();
-  axiosClient.defaults.headers.common["X-SWDC-Tracker-Version"] = version || "";
-  axiosClient.defaults.headers.common["X-SWDC-Tracker-Id"] = name || "swdc-tracker";
+  const { name, version } = getPackageJson();
+  axiosClient.defaults.headers.common["X-SWDC-Tracker-Version"] = version;
+  axiosClient.defaults.headers.common["X-SWDC-Tracker-Id"] = name;
 }
 
 export async function get(endpoint: string, jwt?: string) {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getPackageInfo } from "./env_helper";
 
 // build the axios api base url
 let axiosClient: any = {};
@@ -9,15 +10,8 @@ export function setBaseUrl(url: string) {
     timeout: 15000 // timeout so we're not getting ECONNRESET
   });
 
-  // set teh tracker version and ID
-  let version = process.env.npm_package_version;
-  let name = process.env.npm_package_name;
-  if (!version) {
-    const fs = require("fs");
-    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
-    version = packageJson.version;
-    name = packageJson.name;
-  }
+  // set the tracker version and ID
+  const { name, version } = getPackageInfo();
   axiosClient.defaults.headers.common["X-SWDC-Tracker-Version"] = version || "";
   axiosClient.defaults.headers.common["X-SWDC-Tracker-Id"] = name || "swdc-tracker";
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getPackageInfo } from "./env_helper";
+import { getPackageInfoFromFile } from "./env_helper";
 
 // build the axios api base url
 let axiosClient: any = {};
@@ -11,7 +11,7 @@ export function setBaseUrl(url: string) {
   });
 
   // set the tracker version and ID
-  const { name, version } = getPackageInfo();
+  const { name, version } = getPackageInfoFromFile();
   axiosClient.defaults.headers.common["X-SWDC-Tracker-Version"] = version || "";
   axiosClient.defaults.headers.common["X-SWDC-Tracker-Id"] = name || "swdc-tracker";
 }

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,0 +1,21 @@
+import { getPackageInfo, getPackageInfoFromFile } from "../../src/utils/env_helper";
+
+const expect = require("chai").expect;
+
+describe("configTests", function () {
+
+	context("validate package environment", function () {
+		it("verify version from env", function () {
+			const { name, version } = getPackageInfo();
+			const versionParts = version.split(".");
+			expect(parseInt(versionParts[2], 10)).to.be.gt(0);
+		});
+
+		it("verify version from package file", function () {
+			const { name, version } = getPackageInfoFromFile();
+			const versionParts = version.split(".");
+			expect(parseInt(versionParts[2], 10)).to.be.gt(0);
+		});
+	});
+
+});

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,4 +1,4 @@
-import { getPackageInfoFromFile } from "../../src/utils/env_helper";
+import { getPackageJson } from "../../src/utils/env_helper";
 
 const expect = require("chai").expect;
 
@@ -6,7 +6,7 @@ describe("configTests", function () {
 
 	context("validate package environment", function () {
 		it("verify version from package file", function () {
-			const { name, version } = getPackageInfoFromFile();
+			const { version } = getPackageJson();
 			const versionParts = version.split(".");
 			expect(parseInt(versionParts[2], 10)).to.be.gt(0);
 		});

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,16 +1,10 @@
-import { getPackageInfo, getPackageInfoFromFile } from "../../src/utils/env_helper";
+import { getPackageInfoFromFile } from "../../src/utils/env_helper";
 
 const expect = require("chai").expect;
 
 describe("configTests", function () {
 
 	context("validate package environment", function () {
-		it("verify version from env", function () {
-			const { name, version } = getPackageInfo();
-			const versionParts = version.split(".");
-			expect(parseInt(versionParts[2], 10)).to.be.gt(0);
-		});
-
 		it("verify version from package file", function () {
 			const { name, version } = getPackageInfoFromFile();
 			const versionParts = version.split(".");


### PR DESCRIPTION
Notion shows that the editor action supports sending the repo entity with this event. This updates the javascript tracker to show that it is part of the interface.

I've tested sending the editor action to staging and the repo information is available with that event.

Here's what the header looks like:
header: 'POST api.software.com/user_encrypted_data HTTP/1.1\r\n' +
        'Accept: application/json, text/plain, */*\r\n' +
        'X-SWDC-Tracker-Version: 1.0.20\r\n' +
        'X-SWDC-Tracker-Id: swdc-tracker\r\n' +
        'Authorization: JWT 123\r\n' +
        'Content-Type: application/json;charset=utf-8\r\n' +
        'User-Agent: axios/0.19.2\r\n' +
        'Content-Length: 188\r\n' +
        'Host: localhost\r\n' +
...