### PR TITLE
change how we post to /user_encrypted_data to fix duplicate hash errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/node": "^14.0.13",
     "axios": "^0.19.2",
+    "file-it": "^1.0.24",
     "libsodium": "^0.7.6",
     "libsodium-wrappers": "^0.7.6",
     "lodash": "^4.17.19",

--- a/src/entities/file.ts
+++ b/src/entities/file.ts
@@ -1,4 +1,4 @@
-import { hashValue } from "../utils/hash";
+import { hashValues } from "../utils/hash";
 
 // The file entity
 export interface FileInterface {
@@ -29,14 +29,16 @@ export class File implements FileInterface {
   }
 
   async buildPayload(jwt: string) {
-    const hashedName = await hashValue(this.file_name.replace(/\\/g, "/"), "file_name", jwt);
-    const hashedPath = await hashValue(this.file_path, "file_path", jwt);
+    const hashedValues = await hashValues([
+      { value: this.file_name.replace(/\\/g, "/"), dataType: "file_name" },
+      { value: this.file_path, dataType: "file_path" }
+    ], jwt)
 
     return {
       schema: "iglu:com.software/file/jsonschema/1-0-1",
       data: {
-        file_name: hashedName,
-        file_path: hashedPath,
+        file_name: hashedValues.file_name,
+        file_path: hashedValues.file_path,
         syntax: this.syntax,
         line_count: this.line_count,
         character_count: this.character_count

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -1,4 +1,4 @@
-import { hashValue } from "../utils/hash";
+import { hashValues } from "../utils/hash";
 
 // The project entity
 export interface ProjectInterface {
@@ -20,15 +20,16 @@ export class Project implements ProjectInterface {
   }
 
   async buildPayload(jwt: string) {
-
-    const hashedName = await hashValue(this.project_name, "project_name", jwt);
-    const hashedDirectory = await hashValue(this.project_directory, "project_directory", jwt);
+    const hashedValues = await hashValues([
+      { value: this.project_name, dataType: "project_name" },
+      { value: this.project_directory, dataType: "project_directory" }
+    ], jwt)
 
     return {
       schema: "iglu:com.software/project/jsonschema/1-0-0",
       data: {
-        project_name: hashedName,
-        project_directory: hashedDirectory
+        project_name: hashedValues.project_name,
+        project_directory: hashedValues.project_directory
       }
     }
   }

--- a/src/entities/repo.ts
+++ b/src/entities/repo.ts
@@ -1,4 +1,4 @@
-import { hashValue } from "../utils/hash";
+import { hashValues } from "../utils/hash";
 
 // The repo entity
 export interface RepoInterface {
@@ -29,21 +29,22 @@ export class Repo implements RepoInterface {
   }
 
   async buildPayload(jwt: string) {
-
-    const hashedName = await hashValue(this.repo_name, "repo_name", jwt);
-    const hashedIdentifier = await hashValue(this.repo_identifier, "repo_identifier", jwt);
-    const hashedOwnerId = await hashValue(this.owner_id, "owner_id", jwt);
-    const hashedGitBranch = await hashValue(this.git_branch, "git_branch", jwt);
-    const hashedGitTag = await hashValue(this.git_tag, "git_tag", jwt);
+    const hashedValues = await hashValues([
+        { value: this.repo_name, dataType: "repo_name"},
+        { value: this.repo_identifier, dataType: "repo_identifer"},
+        { value: this.owner_id, dataType: "owner_id" },
+        { value: this.git_branch, dataType: "git_branch" },
+        { value: this.git_tag, dataType: "git_tag" },
+    ], jwt)
 
     return {
       schema: "iglu:com.software/repo/jsonschema/1-0-0",
       data: {
-        repo_identifier: hashedIdentifier,
-        repo_name: hashedName,
-        owner_id: hashedOwnerId,
-        git_branch: hashedGitBranch,
-        git_tag: hashedGitTag
+        repo_identifier: hashedValues.repo_identifer,
+        repo_name: hashedValues.repo_name,
+        owner_id: hashedValues.owner_id,
+        git_branch: hashedValues.git_branch,
+        git_tag:hashedValues.git_tag 
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { UIInteractionParams, UIInteraction } from "./events/ui_interaction";
 import { buildContexts } from "./utils/context_helper";
 
 const snowplow = require("snowplow-tracker");
-
 const emitter = snowplow.emitter;
 const tracker = snowplow.tracker;
 const swdcTracker = <any>{};
@@ -31,7 +30,6 @@ swdcTracker.initialize = async (swdcApiHost: string, namespace: string, appId: s
 
     swdcTracker.spTracker = tracker([e], namespace, appId, false)
     swdcTracker.spTracker.setPlatform('iot');
-
 
     if (isTestMode()) {
       console.log('swdc-tracker test mode on. set env ENABLE_SWDC_TRACKER to "true" to send events');

--- a/src/utils/context_helper.ts
+++ b/src/utils/context_helper.ts
@@ -5,7 +5,6 @@ import { Project } from "../entities/project";
 import { Repo } from "../entities/repo";
 import { File } from "../entities/file";
 import { Plugin } from "../entities/plugin";
-import { UIInteraction } from "../events/ui_interaction";
 import { UIElement } from "../entities/ui_element";
 
 /**

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,44 @@
+const os = require("os");
+const fs = require("fs");
+const fileIt = require("file-it");
+
+export async function storeHashedValues(userHashedValues: any) {
+  fileIt.writeJsonFileSync(getSoftwareHashedValuesFile(), userHashedValues);
+}
+
+export function getStoredHashedValues() {
+  return fileIt.readJsonFileSync(getSoftwareHashedValuesFile());
+}
+
+export function getFile(name: string) {
+  let file_path = getSoftwareDir();
+  if (isWindows()) {
+      return `${file_path}\\${name}`;
+  }
+
+  return `${file_path}/${name}`;
+}
+
+export function isWindows() {
+  return process.platform.indexOf("win32") !== -1;
+}
+
+export function getSoftwareDir(autoCreate = true) {
+  const homedir = os.homedir();
+  let softwareDataDir = homedir;
+  if (isWindows()) {
+      softwareDataDir += "\\.software";
+  } else {
+      softwareDataDir += "/.software";
+  }
+
+  if (autoCreate && !fs.existsSync(softwareDataDir)) {
+      fs.mkdirSync(softwareDataDir);
+  }
+
+  return softwareDataDir;
+}
+
+export function getSoftwareHashedValuesFile() {
+  return getFile("hashed_values.json");
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -4,11 +4,20 @@ import { storeHashedValues, getStoredHashedValues } from "../utils/file";
 const _sodium = require('libsodium-wrappers');
 let sodium: any;
 
+let lastJwt: string = "";
+
 export async function hashValues(payload: any, jwt: string) {
   if (sodium === undefined) {
-    await Promise.all([setUserHashedValues(jwt), _sodium.ready]).then(() => {
+    await Promise.all([_sodium.ready]).then(() => {
       sodium = _sodium;
     });
+  }
+
+  // if the jwt is different from the last fetch (different user, or initializing tracker)
+  // fetch the hashed values and store them in ~/.software/hashed_values.json
+  if(lastJwt !== jwt) {
+    await setUserHashedValues(jwt);
+    lastJwt = jwt;
   }
 
   let result: any = {}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -8,7 +8,7 @@ let lastJwt: string = "";
 
 export async function hashValues(payload: any, jwt: string) {
   if (sodium === undefined) {
-    await Promise.all([_sodium.ready]).then(() => {
+    await Promise.resolve(_sodium.ready).then(() => {
       sodium = _sodium;
     });
   }

--- a/test/utils/hash_test.ts
+++ b/test/utils/hash_test.ts
@@ -1,7 +1,6 @@
 import { 
   hashValues, 
   hasHashValueInCache, 
-  setUserHashedValues,
 } from "../../src/utils/hash";
 import { expect } from 'chai'
 

--- a/test/utils/hash_test.ts
+++ b/test/utils/hash_test.ts
@@ -2,7 +2,6 @@ import {
   hashValues, 
   hasHashValueInCache, 
   setUserHashedValues,
-  userHashedValues
 } from "../../src/utils/hash";
 import { expect } from 'chai'
 
@@ -51,26 +50,6 @@ describe("hashedValues", function () {
       await hasHashValueInCache("foobar", "54321");
       const result = await hasHashValueInCache("foobar", "54321");
       expect(result).to.eq(true);
-    });
-  });
-
-  describe("setUserHashedValues", function() {
-    beforeEach(function () {
-      sandbox.restore();
-      sandbox.stub(http, "get").callsFake(function () {
-        return { data: [{ foo: ["bar"] }] }
-      });
-    });
-  
-    afterEach(function () {
-      sandbox.restore();
-    });
-
-    it("sets the userHashedValues eq to the response.data", async function() {
-      await setUserHashedValues("jwt-token");
-      expect(userHashedValues).to.eql([
-        { foo: ["bar"] }
-      ])
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.26.tgz#22a3b8a46510da8944b67bfc27df02c34a35331c"
   integrity sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==
 
+"@types/universalify@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/universalify/-/universalify-1.0.0.tgz#0fecec0da49839da8b705ddc714600c480ea3dee"
+  integrity sha512-Cqm/s2DU7YxTcTtQZkfG7kyOULQKsl0Mpd3dKAm0CbSStcRsQdy1nctCBGCmyNvxWUEYReqWkBIUvNHBN/Ja6w==
+
 ajv@^6.5.5:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
@@ -426,6 +431,14 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+file-it@^1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/file-it/-/file-it-1.0.24.tgz#55950ea75c6f391576a87185fbf87ec7b6a5256a"
+  integrity sha512-u5rH0cx+tDytzRYsEqGdyb2rLJKkwZZk4sDfJxqrK1K3i6/Sx5GtWja/HHn1UJ0PVHbsI4AF/ciQhWp5JSQqQw==
+  dependencies:
+    "@types/universalify" "^1.0.0"
+    universalify "^1.0.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1251,6 +1264,11 @@ typescript@^3.9.5:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
1. shove the value in the userHashedValues before posting (this will ensure a subsequent call with the same hashedValue won't try to reencrypt)
2. await the setUserHashedValues after a post. This will overwrite the userHashedValues to ensure it's up to date with whatever we have on the backend. 