### PR TITLE
fixed unhandled exception when using the replace function

### DIFF
--- a/src/entities/file.ts
+++ b/src/entities/file.ts
@@ -1,12 +1,13 @@
 import { hashValues } from "../utils/hash";
+import { convertWinPathToUnix } from "../utils/common_helper";
 
 // The file entity
 export interface FileInterface {
-  file_name: string,
-  file_path: string,
-  syntax: string,
-  line_count: number,
-  character_count: number
+  file_name: string;
+  file_path: string;
+  syntax: string;
+  line_count: number;
+  character_count: number;
 }
 
 export class File implements FileInterface {
@@ -29,10 +30,13 @@ export class File implements FileInterface {
   }
 
   async buildPayload(jwt: string) {
-    const hashedValues = await hashValues([
-      { value: this.file_name.replace(/\\/g, "/"), dataType: "file_name" },
-      { value: this.file_path, dataType: "file_path" }
-    ], jwt)
+    const hashedValues = await hashValues(
+      [
+        { value: convertWinPathToUnix(this.file_name), dataType: "file_name" },
+        { value: this.file_path, dataType: "file_path" },
+      ],
+      jwt
+    );
 
     return {
       schema: "iglu:com.software/file/jsonschema/1-0-1",
@@ -41,9 +45,8 @@ export class File implements FileInterface {
         file_path: hashedValues.file_path,
         syntax: this.syntax,
         line_count: this.line_count,
-        character_count: this.character_count
-      }
-    }
+        character_count: this.character_count,
+      },
+    };
   }
-
 }

--- a/src/utils/common_helper.ts
+++ b/src/utils/common_helper.ts
@@ -1,0 +1,5 @@
+export function convertWinPathToUnix(val: any) {
+  // use the "?" to prevent getting...
+  // "TypeError: Cannot read property 'replace' of null"
+  return val?.replace(/\\/g, "/");
+}

--- a/test/utils/string_test.ts
+++ b/test/utils/string_test.ts
@@ -1,0 +1,11 @@
+import { expect } from "chai";
+import { convertWinPathToUnix } from "../../src/utils/common_helper";
+
+const http = require("../../src/utils/http");
+describe("hashedValues", function () {
+  it("doesn't throw unhandled exception with null file name", async function () {
+    const val = null;
+    const newVal = convertWinPathToUnix(val);
+    expect(newVal).to.be.undefined;
+  });
+});


### PR DESCRIPTION
code time and 100doc are getting unhandled exceptions ""TypeError: Cannot read property 'replace' of null"" when we send a null file_name to the tracker.