### PR TITLE
setTimezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swdc-tracker",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "swdc event tracker",
   "main": "dist",
   "types": "dist/index.d.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ swdcTracker.initialize = async (swdcApiHost: string, namespace: string, appId: s
 
     swdcTracker.spTracker = tracker([e], namespace, appId, false)
     swdcTracker.spTracker.setPlatform('iot');
+    swdcTracker.spTracker.setTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
 
     if (isTestMode()) {
       console.log('swdc-tracker test mode on. set env ENABLE_SWDC_TRACKER to "true" to send events');


### PR DESCRIPTION
Sets the timezone. This works in all browsers but from what I've read it looks like in some Node environments, some timezones might not show up properly (e.g. GMT+7).

https://www.notion.so/softwaredotcom/OS-timezone-08ea15d733354136b9e4e7c05c1c8ef5

![Screen Shot 2020-10-01 at 9 55 35 PM](https://user-images.githubusercontent.com/27828739/94880707-b5817180-0431-11eb-9b74-d4d5d1a8d484.png)
