### PR TITLE
bump file-it to prevent stringifying a null object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swdc-tracker",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "swdc event tracker",
   "main": "dist",
   "types": "dist/index.d.js",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@types/node": "^14.0.13",
     "axios": "^0.21.1",
-    "file-it": "^1.0.24",
+    "file-it": "^1.1.1",
     "libsodium": "^0.7.6",
     "libsodium-wrappers": "^0.7.6",
     "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,13 +425,13 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-file-it@^1.0.24:
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/file-it/-/file-it-1.0.24.tgz#55950ea75c6f391576a87185fbf87ec7b6a5256a"
-  integrity sha512-u5rH0cx+tDytzRYsEqGdyb2rLJKkwZZk4sDfJxqrK1K3i6/Sx5GtWja/HHn1UJ0PVHbsI4AF/ciQhWp5JSQqQw==
+file-it@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/file-it/-/file-it-1.1.1.tgz#35260f9da20a39575df5549ffa683e91f771f49e"
+  integrity sha512-MeeuXiYLk3A1Mk4mJshy3+r/dpAZGu6THxADrXqKzVphbH4ZZmJwZh/vNVuYRmMsSoKTsVUNG0+HaPMplqtsgg==
   dependencies:
     "@types/universalify" "^1.0.0"
-    universalify "^1.0.0"
+    universalify "^2.0.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1256,10 +1256,10 @@ typescript@^3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-universalify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
-  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
While debugging atom, i noticed an the atom's debug console throw json format exceptions which showed that the file-it npm was trying to JSON.stringify a null object to the encrypt-values.json file.

