### PR TITLE
normalize payload data to hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swdc-tracker",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "swdc event tracker",
   "main": "dist",
   "types": "dist/index.d.js",

--- a/test/events/codetime.test.ts
+++ b/test/events/codetime.test.ts
@@ -1,7 +1,6 @@
 import swdcTracker, { CodeTime } from "../../src/index";
 import { TrackerResponse } from "../../src/utils/response";
 
-const hash = require("object-hash");
 const http = require("../../src/utils/http");
 const expect = require("chai").expect;
 const sinon = require("sinon");
@@ -110,7 +109,7 @@ describe("Test codetime event functions", function () {
     };
 
     const codetimePayload: any = new CodeTime(eventData).buildPayload();
-    const payloadHash = hash(codetimePayload);
+    const payloadHash = swdcTracker.getEventDataHash(codetimePayload.data);
 
     await swdcTracker.trackCodeTimeEvent(eventData);
     let outgoingPayload = swdcTracker.getOutgoingParamsData("codetime_event", payloadHash);

--- a/test/events/editor_action.test.ts
+++ b/test/events/editor_action.test.ts
@@ -1,7 +1,6 @@
 import swdcTracker, { EditorAction } from "../../src/index";
 import { TrackerResponse } from "../../src/utils/response";
 
-const hash = require("object-hash");
 const http = require("../../src/utils/http");
 const expect = require("chai").expect;
 const sinon = require("sinon");
@@ -71,7 +70,7 @@ describe("Test editor action event functions", function () {
     };
 
     const editorActionPayload: any = new EditorAction(eventData).buildPayload();
-    const payloadHash = hash(editorActionPayload);
+    const payloadHash = swdcTracker.getEventDataHash(editorActionPayload.data);
 
     await swdcTracker.trackEditorAction(eventData);
 

--- a/test/events/git_event.test.ts
+++ b/test/events/git_event.test.ts
@@ -1,3 +1,4 @@
+import { GitEvent, GitEventInterface } from "../../src/events/git_event";
 import swdcTracker from "../../src/index";
 import { TrackerResponse } from "../../src/utils/response";
 
@@ -114,6 +115,19 @@ describe("Test git_event functions", function () {
 
       expect(http.post).to.not.have
         .been.calledWith("/user_encrypted_data", sinon.match.any, sinon.match.any)
+    });
+
+    it("Stores the git event params to reconcile", async function () {
+      const eventData: any = {
+        git_event_type: "uncommitted_change"
+      };
+
+      const gitEventPayload: any = new GitEvent(eventData).buildPayload();
+      const payloadHash = swdcTracker.getEventDataHash(gitEventPayload.data);
+      await swdcTracker.trackGitEvent(eventData);
+
+      const outgoingPayload = swdcTracker.getOutgoingParamsData("git_event", payloadHash);
+      expect(outgoingPayload.git_event_type).to.eq("uncommitted_change");
     });
   });
 });


### PR DESCRIPTION
* Further testing showed the git event payload may or may not have attribute values such as commit_id which changes the hash output.
* This PR normalizes the buildPayload data to ensure hashing is the same when sending the event and getting the event data on the success callback