### PR TITLE
Bump vscode_extension schema version to 1-0-1

### DIFF
--- a/src/entities/vscode_extension.ts
+++ b/src/entities/vscode_extension.ts
@@ -12,14 +12,14 @@ export interface VSCodeExtensionInterface {
 }
 
 export class VSCodeExtension implements VSCodeExtensionInterface {
-  public id: string; // "The canonical extension identifier in the form of: `publisher.name`" - (max len: 510)
-  public publisher: string; // (max len: 255)
-  public name: string; // (max len: 255)
-  public display_name: string; // (max len: 255)
-  public author: string; // (max len: 255)
+  public id: string; // "The canonical extension identifier in the form of: `publisher.name`" - (max len: 1024)
+  public publisher: string; // (max len: 512)
+  public name: string; // (max len: 512)
+  public display_name: string; // (max len: 2048)
+  public author: string; // (max len: 512)
   public version: string; // (max len: 255)
   public description: string; // (max len: 2048)
-  public categories: string[]; // (max len: 510)
+  public categories: string[]; // (max len per category string: 510)
   public extension_kind: string[]; // In a remote window the extension kind describes if an extension runs where the UI (window) runs or if an extension runs remotely. (max len: 255)
 
   constructor(data: VSCodeExtensionInterface) {
@@ -41,7 +41,7 @@ export class VSCodeExtension implements VSCodeExtensionInterface {
 
   async buildPayload() {
     return {
-      schema: 'iglu:com.software/vscode_extension/jsonschema/1-0-0',
+      schema: 'iglu:com.software/vscode_extension/jsonschema/1-0-1',
       data: {
         id: this.id,
         publisher: this.publisher,

--- a/src/utils/context_helper.ts
+++ b/src/utils/context_helper.ts
@@ -54,8 +54,8 @@ export async function buildContexts(params: any) {
   }
 
   // vscode extension event
-  if (VSCodeExtension.hasData(params)) {
-    const _vscodeExtension = await new VSCodeExtension(params).buildPayload();
+  if (params.vscode_extension && VSCodeExtension.hasData(params.vscode_extension)) {
+    const _vscodeExtension = await new VSCodeExtension(params.vscode_extension).buildPayload();
     contexts.push(_vscodeExtension);
   }
 

--- a/test/events/vscode_extension_event.test.ts
+++ b/test/events/vscode_extension_event.test.ts
@@ -39,15 +39,17 @@ describe('VSCode Extension Event', function () {
       action: 'installed',
       event_at: '2023-02-13T04:00:00Z',
       os: 'Darwin_22.1.0_darwin',
-      id: 'softwaredotcom.swdc-vscode',
-      publisher: 'softwaredotcom',
-      name: 'swdc-vscode',
-      display_name: 'Code Time',
-      author: 'Software.com',
-      version: '2.6.44',
-      description: 'Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.',
-      categories: ["Other"],
-      extension_kind: ["ui", "workspace"]
+      vscode_extension: {
+        id: 'softwaredotcom.swdc-vscode',
+        publisher: 'softwaredotcom',
+        name: 'swdc-vscode',
+        display_name: 'Code Time',
+        author: 'Software.com',
+        version: '2.6.44',
+        description: 'Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.',
+        categories: ["Other"],
+        extension_kind: ["ui", "workspace"]
+      }
     };
 
     it('returns a 200 status', async function () {
@@ -69,7 +71,27 @@ describe('VSCode Extension Event', function () {
       const contexts = swdcTracker.getLastProcessedTestEvent().contexts;
       const vscodeExtensionContext: any = contexts.find((n: any) => n.schema.includes('vscode_extension'));
 
-      expect(eventData).to.include(vscodeExtensionContext.data);
+      expect(vscodeExtensionContext.data).to.eql(
+        {
+          id: 'softwaredotcom.swdc-vscode',
+          publisher: 'softwaredotcom',
+          name: 'swdc-vscode',
+          display_name: 'Code Time',
+          author: 'Software.com',
+          version: '2.6.44',
+          description: 'Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.',
+          categories: [ 'Other' ],
+          extension_kind: [ 'ui', 'workspace' ]
+        }
+      );
+    })
+
+    it("has the auth context", async function() {
+      await swdcTracker.trackVSCodeExtension(eventData);
+      const contexts = swdcTracker.getLastProcessedTestEvent().contexts;
+      const auth: any = contexts.find((n: any) => n.schema.includes('auth'));
+
+      expect(auth.data).to.eql({ "jwt": "JWT 123" });
     })
   });
 });


### PR DESCRIPTION
- This version allows fields to contain longer values.
- Also changed the vscode_extension properties to be nested to avoid any issues with name collisions.